### PR TITLE
fix: no permission property inside steps and skip sarif upload on skip…

### DIFF
--- a/docs/guides/github-code-scanning.md
+++ b/docs/guides/github-code-scanning.md
@@ -27,21 +27,27 @@ produces a SARIF report which can be uploaded to GitHub.
 Invoke `vet-action` to run `vet` in GitHub
 
 ```yaml
-- name: Run vet
-  id: vet
-  permissions:
-    contents: read
-    issues: write
-    pull-requests: write
-  uses: safedep/vet-action@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  
+jobs:
+  vet-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run vet
+        id: vet
+        uses: safedep/vet-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 Upload the SARIF report to GitHub
 
 ```yaml
 - name: Upload SARIF
+  if: steps.vet.outputs.report != ''
   uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: ${{ steps.vet.outputs.report }}

--- a/docs/guides/github-code-scanning.md
+++ b/docs/guides/github-code-scanning.md
@@ -36,6 +36,9 @@ jobs:
   vet-scan:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Run vet
         id: vet
         uses: safedep/vet-action@v1

--- a/docs/guides/github-code-scanning.md
+++ b/docs/guides/github-code-scanning.md
@@ -48,6 +48,13 @@ jobs:
 
 Upload the SARIF report to GitHub
 
+:::info
+
+SARIF reports work when you enable GitHub Code Scanning in your repository.
+[Learn more](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning)
+
+:::
+
 ```yaml
 - name: Upload SARIF
   if: steps.vet.outputs.report != ''


### PR DESCRIPTION
…ed pr

1. There is no property called `permissions` inside steps inside GitHub actions, before version was causing syntax error. 

2. When scan is skipped due to no changes, upload sarif is failed (with error or file not found)

![image](https://github.com/user-attachments/assets/ae2a39bc-5a08-4e63-a26c-9d57d6f71b98)
